### PR TITLE
fix stdlib & option '+'

### DIFF
--- a/src/tbox/libc/stdlib/stdlib.c
+++ b/src/tbox/libc/stdlib/stdlib.c
@@ -90,6 +90,9 @@ tb_uint64_t tb_s8tou64(tb_char_t const* s)
         s++;
     }
 
+    if (*s == '+')
+        s++;
+
     // skip '0'
     while ((*s) == '0') s++;
 
@@ -127,6 +130,9 @@ tb_uint64_t tb_s10tou64(tb_char_t const* s)
         s++;
     }
 
+    if (*s == '+')
+        s++;
+
     // skip '0'
     while ((*s) == '0') s++;
 
@@ -163,6 +169,9 @@ tb_uint64_t tb_s16tou64(tb_char_t const* s)
         sign = 1;
         s++;
     }
+
+    if (*s == '+')
+        s++;
 
     // skip "0x"
     if (s[0] == '0' && (s[1] == 'x' || s[1] == 'X'))
@@ -203,7 +212,7 @@ tb_uint64_t tb_stou64(tb_char_t const* s)
     while (tb_isspace(*p)) p++;
 
     // has sign?
-    if (*p == '-') p++;
+    if (*p == '-' || *p == '+') p++;
 
     // is hex?
     if (*p++ == '0')
@@ -263,6 +272,9 @@ tb_double_t tb_s2tod(tb_char_t const* s)
         sign = 1;
         s++;
     }
+
+    if (*s == '+')
+        s++;
 
     // nan?
     if (s[0] == 'n' && s[1] == 'a' && s[2] == 'n')
@@ -351,6 +363,9 @@ tb_double_t tb_s8tod(tb_char_t const* s)
         s++;
     }
 
+    if (*s == '+')
+        s++;
+
     // nan?
     if (s[0] == 'n' && s[1] == 'a' && s[2] == 'n')
         return TB_NAN;
@@ -438,6 +453,9 @@ tb_double_t tb_s10tod(tb_char_t const* s)
         s++;
     }
 
+    if (*s == '+')
+        s++;
+
     // nan?
     if (s[0] == 'n' && s[1] == 'a' && s[2] == 'n')
         return TB_NAN;
@@ -524,6 +542,9 @@ tb_double_t tb_s16tod(tb_char_t const* s)
         sign = 1;
         s++;
     }
+
+    if (*s == '+')
+        s++;
 
     // nan?
     if (s[0] == 'n' && s[1] == 'a' && s[2] == 'n')
@@ -649,7 +670,7 @@ tb_double_t tb_stod(tb_char_t const* s)
     while (tb_isspace(*p)) p++;
 
     // has sign?
-    if (*p == '-') p++;
+    if (*p == '-' || *p == '+') p++;
 
     // is hex?
     if (*p++ == '0')

--- a/src/tbox/utils/option.c
+++ b/src/tbox/utils/option.c
@@ -75,8 +75,8 @@ static __tb_inline__ tb_bool_t tb_option_is_integer(tb_char_t const* data)
     // init
     tb_char_t const* p = data;
 
-    // skip '-'
-    if (*p == '-') p++;
+    // skip '-' & '+'
+    if (*p == '-' || *p == '+') p++;
 
     // walk
     for (; *p && tb_isdigit(*p); p++);


### PR DESCRIPTION
修复在stdlib和option中，出现`+1`无法识别的情况。