### PR TITLE
Fix path.c bug

### DIFF
--- a/src/tbox/platform/path.c
+++ b/src/tbox/platform/path.c
@@ -49,7 +49,11 @@
 #endif
 
 // is path separator?
-#define tb_path_is_separator(c)     ((c) == '/' || (c) == '\\')
+#ifdef TB_CONFIG_OS_WINDOWS
+#    define tb_path_is_separator(c)     ((c) == '/' || (c) == '\\')
+#else
+#    define tb_path_is_separator(c)     ((c) == '/')
+#endif
 
 /* //////////////////////////////////////////////////////////////////////////////////////
  * implementation


### PR DESCRIPTION
在`linux`下`\`可以作为目录名，但是path 会把它当成分隔符。