### PR TITLE
fix  int socket(int, int, int)  in iOS

### DIFF
--- a/src/tbox/platform/socket.h
+++ b/src/tbox/platform/socket.h
@@ -59,10 +59,10 @@ typedef enum __tb_socket_type_e
 ,   TB_SOCKET_TYPE_UDP                  = TB_SOCKET_TYPE_SOCK_DGRAM  | TB_SOCKET_TYPE_IPPROTO_UDP
 
 #if defined(TB_CONFIG_OS_MACOSX) || defined(TB_CONFIG_OS_IOS)
-    // socket for icmp, only need user permission on macOS
+    // socket for icmp, only need user permission on macOS/iOS
 ,   TB_SOCKET_TYPE_ICMP                 = TB_SOCKET_TYPE_SOCK_DGRAM  | TB_SOCKET_TYPE_IPPROTO_ICMP
 #else
-    // socket for icmp, need root permission on linux/macOS
+    // socket for icmp, need root permission on linux/windows
 ,   TB_SOCKET_TYPE_ICMP                 = TB_SOCKET_TYPE_SOCK_RAW    | TB_SOCKET_TYPE_IPPROTO_ICMP
 #endif
 

--- a/src/tbox/platform/socket.h
+++ b/src/tbox/platform/socket.h
@@ -58,7 +58,7 @@ typedef enum __tb_socket_type_e
     // socket for udp
 ,   TB_SOCKET_TYPE_UDP                  = TB_SOCKET_TYPE_SOCK_DGRAM  | TB_SOCKET_TYPE_IPPROTO_UDP
 
-#ifdef TB_CONFIG_OS_MACOSX
+#if defined(TB_CONFIG_OS_MACOSX) || defined(TB_CONFIG_OS_IOS)
     // socket for icmp, only need user permission on macOS
 ,   TB_SOCKET_TYPE_ICMP                 = TB_SOCKET_TYPE_SOCK_DGRAM  | TB_SOCKET_TYPE_IPPROTO_ICMP
 #else


### PR DESCRIPTION
```c
#if defined(TB_CONFIG_OS_MACOSX) || defined(TB_CONFIG_OS_IOS)
    // socket for icmp, only need user permission on macOS
,   TB_SOCKET_TYPE_ICMP                 = TB_SOCKET_TYPE_SOCK_DGRAM  | TB_SOCKET_TYPE_IPPROTO_ICMP
#else
    // socket for icmp, need root permission on linux/macOS
,   TB_SOCKET_TYPE_ICMP                 = TB_SOCKET_TYPE_SOCK_RAW    | TB_SOCKET_TYPE_IPPROTO_ICMP
#endif
```

注释中"// socket for icmp, need root permission on linux/macOS"是不是应该为"linux/Windows"?