### PR TITLE
Fix issue: `tb_http_close` can't fully close socks, leave CLOSE_WAIT actually

### DIFF
--- a/src/tbox/stream/impl/stream/sock.c
+++ b/src/tbox/stream/impl/stream/sock.c
@@ -747,6 +747,9 @@ tb_stream_ref_t tb_stream_init_sock()
     {
         // init sock type
         stream_sock->type = TB_SOCKET_TYPE_TCP;
+
+        // mark as owner of socket
+        stream_sock->owner = 1;
     }
 
     // ok?
@@ -776,8 +779,7 @@ tb_stream_ref_t tb_stream_init_from_sock(tb_char_t const* host, tb_uint16_t port
         tb_stream_sock_t* stream_sock = tb_stream_sock_cast(stream);
         tb_assert_and_check_break(stream_sock);
 
-        // mark as owner of socket
-        stream_sock->owner = 1;
+     
    
         // ok
         ok = tb_true;


### PR DESCRIPTION
Hi,

Firstly, thanks tbox team to build such a nice C library 🙏

And I found an issue when developing my own project using tbox and may found the reason. So i create this PR and may solve that problem.

Minimal reproducible example here:  

https://gist.github.com/CuberL/250e3687875376985bde9cfb013e922f

when you run the code, and see the connection status using `netstat` or `lsof`, u will find that all of these connections are in status `CLOSE_WAIT`. 

![image](https://user-images.githubusercontent.com/3540324/79945455-5f7eca00-84a0-11ea-9b9e-baddf3eafa0b.png)

After tracking the code, i found that problem should be here:

https://github.com/tboox/tbox/blob/46fa8a8c6de62389c92495404faa599f6b9994ee/src/tbox/stream/impl/stream/sock.c#L437

it means the stream_sock need to be marked as owner, but `tb_http_init` call `tb_stream_init_sock ` directly, so never mark that. That cause the problem.

https://github.com/tboox/tbox/blob/46fa8a8c6de62389c92495404faa599f6b9994ee/src/tbox/stream/impl/stream/sock.c#L746-L750

Hope this PR can help you, thanks.
