### PR TITLE
docs: fix simple typo, envirnoment -> environment

### DIFF
--- a/src/tbox/libc/impl/libc.h
+++ b/src/tbox/libc/impl/libc.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init libc envirnoment
+/* init libc environment
  *
  * @return  tb_true or tb_false
  */
 tb_bool_t   tb_libc_init_env(tb_noarg_t);
 
-/* exit libc envirnoment
+/* exit libc environment
  */
 tb_void_t   tb_libc_exit_env(tb_noarg_t);
 

--- a/src/tbox/libm/impl/libm.h
+++ b/src/tbox/libm/impl/libm.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init libm envirnoment
+/* init libm environment
  *
  * @return  tb_true or tb_false
  */
 tb_bool_t   tb_libm_init_env(tb_noarg_t);
 
-/* exit libm envirnoment
+/* exit libm environment
  */
 tb_void_t   tb_libm_exit_env(tb_noarg_t);
 

--- a/src/tbox/math/impl/math.h
+++ b/src/tbox/math/impl/math.h
@@ -35,13 +35,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init math envirnoment
+/* init math environment
  *
  * @return      tb_true or tb_false
  */
 tb_bool_t       tb_math_init_env(tb_noarg_t);
 
-// exit math envirnoment
+// exit math environment
 tb_void_t       tb_math_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/memory/impl/memory.h
+++ b/src/tbox/memory/impl/memory.h
@@ -36,7 +36,7 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init memory envirnoment
+/* init memory environment
  *
  * @param allocator     the allocator
  *
@@ -44,7 +44,7 @@ __tb_extern_c_enter__
  */
 tb_bool_t               tb_memory_init_env(tb_allocator_ref_t allocator);
 
-// exit memory envirnoment
+// exit memory environment
 tb_void_t               tb_memory_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/network/impl/network.h
+++ b/src/tbox/network/impl/network.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/*! init network envirnoment
+/*! init network environment
  *
  * @return      tb_true or tb_false
  */
 tb_bool_t       tb_network_init_env(tb_noarg_t);
 
-/// exit network envirnoment
+/// exit network environment
 tb_void_t       tb_network_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/object/impl/object.h
+++ b/src/tbox/object/impl/object.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init object envirnoment
+/* init object environment
  *
  * @return          tb_true or tb_false
  */
 tb_bool_t           tb_object_init_env(tb_noarg_t);
 
-// exit object envirnoment
+// exit object environment
 tb_void_t           tb_object_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/platform/impl/dns.h
+++ b/src/tbox/platform/impl/dns.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init dns envirnoment
+/* init dns environment
  *
  * @return  tb_true or tb_false
  */
 tb_bool_t   tb_dns_init_env(tb_noarg_t);
 
-// exit dns envirnoment
+// exit dns environment
 tb_void_t   tb_dns_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/platform/impl/exception.h
+++ b/src/tbox/platform/impl/exception.h
@@ -35,13 +35,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init the exception envirnoment
+/* init the exception environment
  *
  * @return          tb_true or tb_false
  */
 tb_bool_t           tb_exception_init_env(tb_noarg_t);
 
-// exit the exception envirnoment
+// exit the exception environment
 tb_void_t           tb_exception_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/platform/impl/platform.c
+++ b/src/tbox/platform/impl/platform.c
@@ -49,27 +49,27 @@ __tb_extern_c_leave__
 
 tb_bool_t tb_platform_init_env(tb_handle_t priv)
 {
-    // init the current platform envirnoment
+    // init the current platform environment
 #if defined(TB_CONFIG_OS_ANDROID)
     if (!tb_android_init_env(priv)) return tb_false;
 #elif defined(TB_CONFIG_OS_WINDOWS)
     if (!tb_windows_init_env()) return tb_false;
 #endif
 
-    // init socket envirnoment
+    // init socket environment
     if (!tb_socket_init_env()) return tb_false;
 
-    // init dns envirnoment
+    // init dns environment
 #ifndef TB_CONFIG_MICRO_ENABLE
     if (!tb_dns_init_env()) return tb_false;
 #endif
 
-    // init thread local envirnoment
+    // init thread local environment
 #ifndef TB_CONFIG_MICRO_ENABLE
     if (!tb_thread_local_init_env()) return tb_false;
 #endif
 
-    // init exception envirnoment
+    // init exception environment
 #ifdef TB_CONFIG_EXCEPTION_ENABLE
     if (!tb_exception_init_env()) return tb_false;
 #endif
@@ -94,25 +94,25 @@ tb_void_t tb_platform_exit_env()
     tb_process_group_exit();
 #endif
 
-    // exit exception envirnoment
+    // exit exception environment
 #ifdef TB_CONFIG_EXCEPTION_ENABLE
     tb_exception_exit_env();
 #endif
 
-    // exit thread local envirnoment
+    // exit thread local environment
 #ifndef TB_CONFIG_MICRO_ENABLE
     tb_thread_local_exit_env();
 #endif
 
-    // exit dns envirnoment
+    // exit dns environment
 #ifndef TB_CONFIG_MICRO_ENABLE
     tb_dns_exit_env();
 #endif
 
-    // exit socket envirnoment
+    // exit socket environment
     tb_socket_exit_env();
 
-    // exit the current platform envirnoment
+    // exit the current platform environment
 #if defined(TB_CONFIG_OS_ANDROID)
     tb_android_exit_env();
 #elif defined(TB_CONFIG_OS_WINDOWS)

--- a/src/tbox/platform/impl/platform.h
+++ b/src/tbox/platform/impl/platform.h
@@ -36,7 +36,7 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/*! init the platform envirnoment
+/*! init the platform environment
  *
  * @param priv      the platform private data
  *                  pass JavaVM* jvm for android
@@ -46,7 +46,7 @@ __tb_extern_c_enter__
  */
 tb_bool_t           tb_platform_init_env(tb_handle_t priv);
 
-/// exit the platform envirnoment
+/// exit the platform environment
 tb_void_t           tb_platform_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/platform/impl/socket.h
+++ b/src/tbox/platform/impl/socket.h
@@ -35,10 +35,10 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-// init socket envirnoment
+// init socket environment
 tb_bool_t   tb_socket_init_env(tb_noarg_t);
 
-// exit socket envirnoment
+// exit socket environment
 tb_void_t   tb_socket_exit_env(tb_noarg_t);
 
 /* //////////////////////////////////////////////////////////////////////////////////////

--- a/src/tbox/platform/impl/thread_local.h
+++ b/src/tbox/platform/impl/thread_local.h
@@ -36,13 +36,13 @@ __tb_extern_c_enter__
  * interfaces
  */
 
-/* init the thread local envirnoment
+/* init the thread local environment
  *
  * @return          tb_true or tb_false
  */
 tb_bool_t           tb_thread_local_init_env(tb_noarg_t);
 
-// exit the thread local envirnoment
+// exit the thread local environment
 tb_void_t           tb_thread_local_exit_env(tb_noarg_t);
 
 /* walk all thread locals

--- a/src/tbox/tbox.c
+++ b/src/tbox/tbox.c
@@ -168,25 +168,25 @@ tb_bool_t tb_init_(tb_handle_t priv, tb_allocator_ref_t allocator, tb_size_t mod
     // init singleton
     if (!tb_singleton_init()) return tb_false;
 
-    // init memory envirnoment
+    // init memory environment
     if (!tb_memory_init_env(allocator)) return tb_false;
 
-    // init platform envirnoment
+    // init platform environment
     if (!tb_platform_init_env(priv)) return tb_false;
 
-    // init libc envirnoment
+    // init libc environment
     if (!tb_libc_init_env()) return tb_false;
 
-    // init math envirnoment
+    // init math environment
     if (!tb_math_init_env()) return tb_false;
 
-    // init libm envirnoment
+    // init libm environment
     if (!tb_libm_init_env()) return tb_false;
 
-    // init network envirnoment
+    // init network environment
     if (!tb_network_init_env()) return tb_false;
 
-    // init object envirnoment
+    // init object environment
 #ifdef TB_CONFIG_MODULE_HAVE_OBJECT
     if (!tb_object_init_env()) return tb_false;
 #endif
@@ -213,25 +213,25 @@ tb_void_t tb_exit()
     tb_object_exit_env();
 #endif
 
-    // exit network envirnoment
+    // exit network environment
     tb_network_exit_env();
 
-    // exit libm envirnoment
+    // exit libm environment
     tb_libm_exit_env();
 
-    // exit math envirnoment
+    // exit math environment
     tb_math_exit_env();
 
-    // exit libc envirnoment
+    // exit libc environment
     tb_libc_exit_env();
 
-    // exit platform envirnoment
+    // exit platform environment
     tb_platform_exit_env();
 
     // exit singleton
     tb_singleton_exit();
 
-    // exit memory envirnoment
+    // exit memory environment
     tb_memory_exit_env();
 
     // trace


### PR DESCRIPTION
There is a small typo in src/tbox/libc/impl/libc.h, src/tbox/libm/impl/libm.h, src/tbox/math/impl/math.h, src/tbox/memory/impl/memory.h, src/tbox/network/impl/network.h, src/tbox/object/impl/object.h, src/tbox/platform/impl/dns.h, src/tbox/platform/impl/exception.h, src/tbox/platform/impl/platform.c, src/tbox/platform/impl/platform.h, src/tbox/platform/impl/socket.h, src/tbox/platform/impl/thread_local.h, src/tbox/tbox.c.

Should read `environment` rather than `envirnoment`.

