### PR TITLE
Adding a platform function: tb_file_access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push]
+on:
+  pull_request:
+  push:
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/src/tbox/platform/file.c
+++ b/src/tbox/platform/file.c
@@ -143,4 +143,9 @@ tb_bool_t tb_file_link(tb_char_t const* path, tb_char_t const* dest)
     tb_trace_noimpl();
     return tb_false;
 }
+tb_bool_t tb_file_access(tb_char_t const* path, tb_size_t mode)
+{
+    tb_trace_noimpl();
+    return tb_false;
+}
 #endif

--- a/src/tbox/platform/file.h
+++ b/src/tbox/platform/file.h
@@ -60,6 +60,7 @@ typedef enum __tb_file_mode_t
 ,   TB_FILE_MODE_APPEND     = 16    //!< append
 ,   TB_FILE_MODE_TRUNC      = 32    //!< truncate
 ,   TB_FILE_MODE_DIRECT     = 64    //!< direct, no cache, @note data & size must be aligned by TB_FILE_DIRECT_ASIZE
+,   TB_FILE_MODE_EXEC       = 128   //!< executable, only for tb_file_access, not supported when creating files, not supported on windows
 
 }tb_file_mode_t;
 
@@ -299,6 +300,15 @@ tb_bool_t               tb_file_rename(tb_char_t const* path, tb_char_t const* d
  * @return              tb_true or tb_false
  */
 tb_bool_t               tb_file_link(tb_char_t const* path, tb_char_t const* dest);
+
+/*! check whether the file or directory can be accessed
+ *
+ * @param path          the path of the file or directory
+ * @param mode          the required accessing mode
+ *
+ * @return              tb_true or tb_false
+ */
+tb_bool_t               tb_file_access(tb_char_t const* path, tb_size_t mode);
 
 /* //////////////////////////////////////////////////////////////////////////////////////
  * extern

--- a/src/tbox/platform/posix/file.c
+++ b/src/tbox/platform/posix/file.c
@@ -588,4 +588,26 @@ tb_bool_t tb_file_link(tb_char_t const* path, tb_char_t const* dest)
     }
     return tb_false;
 }
+tb_bool_t tb_file_access(tb_char_t const* path, tb_size_t mode)
+{
+    // check
+    tb_assert_and_check_return_val(path, tb_false);
+
+    // the full path
+    tb_char_t full[TB_PATH_MAXN];
+    path = tb_path_absolute(path, full, TB_PATH_MAXN);
+    tb_assert_and_check_return_val(path, tb_false);
+
+    // flags
+    tb_size_t flags = 0;
+    if (mode & TB_FILE_MODE_RW) flags = R_OK | W_OK;
+    else
+    {
+        if (mode & TB_FILE_MODE_RO) flags |= R_OK;
+        if (mode & TB_FILE_MODE_WO) flags |= W_OK;
+    }
+    if (mode & TB_FILE_MODE_EXEC) flags |= X_OK;
+
+    return !access(full, flags);
+}
 #endif

--- a/src/tbox/platform/windows/file.c
+++ b/src/tbox/platform/windows/file.c
@@ -535,3 +535,31 @@ tb_bool_t tb_file_link(tb_char_t const* path, tb_char_t const* dest)
     // attempt to link it directly with admin privilege
     return (tb_bool_t)pCreateSymbolicLinkW(full1, path0, isdir? SYMBOLIC_LINK_FLAG_DIRECTORY : 0);
 }
+tb_bool_t tb_file_access(tb_char_t const* path, tb_size_t mode)
+{
+    // check
+    tb_assert_and_check_return_val(path, tb_false);
+
+    // the full path
+    tb_wchar_t full[TB_PATH_MAXN];
+    if (!tb_path_absolute_w(path, full, TB_PATH_MAXN)) return tb_false;
+
+    DWORD perm = FILE_TRAVERSE | SYNCHRONIZE;
+    if (mode & TB_FILE_MODE_RW) perm = GENERIC_READ | GENERIC_WRITE;
+    else
+    {
+        if (mode & TB_FILE_MODE_RO) perm |= GENERIC_READ;
+        if (mode & TB_FILE_MODE_WO) perm |= GENERIC_WRITE;
+    }
+
+    /* The windows POSIX implementation: _access_s and _waccess_s don't work well.
+     * For example, _access_s reports the folder "C:\System Volume Information" can be accessed.
+     * So using the win32 API "CreateFile" here which works much better.
+     */
+    HANDLE h = CreateFileW(full, perm, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                           NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (h == INVALID_HANDLE_VALUE)
+        return tb_false;
+    CloseHandle(h);
+    return tb_true;
+}


### PR DESCRIPTION
This patch adds a function named "tb_file_access" which is a wrapper of
the POSIX function "access".