### PR TITLE
add loongarch support

### DIFF
--- a/src/tbox/prefix/arch.h
+++ b/src/tbox/prefix/arch.h
@@ -179,9 +179,9 @@
 #elif defined(__loongarch__)
 #   define TB_ARCH_LOONGARCH 
 #   if defined(__loongarch64)
-#       define TB_ARCH_STRING           "loongarch64"
+#       define TB_ARCH_STRING               "loongarch64"
 #   elif defined(__loongarch32)
-#       define TB_ARCH_STRING           "loongarch32"
+#       define TB_ARCH_STRING               "loongarch32"
 #   else
 #       error unknown version of LoongArch, please feedback to us.
 #   endif

--- a/src/tbox/prefix/arch.h
+++ b/src/tbox/prefix/arch.h
@@ -176,6 +176,15 @@
 #           define TB_ARCH_STRING           "mips64el"
 #       endif
 #   endif
+#elif defined(__loongarch__)
+#   define TB_ARCH_LOONGARCH 
+#   if defined(__loongarch64)
+#       define TB_ARCH_STRING           "loongarch64"
+#   elif defined(__loongarch32)
+#       define TB_ARCH_STRING           "loongarch32"
+#   else
+#       error unknown version of LoongArch, please feedback to us.
+#   endif
 #elif defined(TB_COMPILER_IS_TINYC)
 #   if defined(TCC_TARGET_I386)
 #       define TB_ARCH_x86

--- a/src/tbox/prefix/cpu.h
+++ b/src/tbox/prefix/cpu.h
@@ -44,6 +44,7 @@
     || defined(__PPC64__) \
     || defined(__ppc64__) \
     || defined(__powerpc64__) \
+    || defined(__loongarch64) \
     || defined(_M_X64) \
     || defined(_M_AMD64) \
     || defined(_M_IA64) \


### PR DESCRIPTION
add LoongArch CPU support and it has been passed testing 100% on an LoongArch64 PC.
only support xmake lua backend building, cannot support luajit backend.

