### PR TITLE
Replace 'finded', which doesn't exist in english, with 'found'

### DIFF
--- a/src/tbox/algorithm/binary_find.h
+++ b/src/tbox/algorithm/binary_find.h
@@ -41,7 +41,7 @@ __tb_extern_c_enter__
  * @param iterator  the iterator
  * @param head      the iterator head
  * @param tail      the iterator tail
- * @param item      the finded item
+ * @param item      the found item
  *
  * @return          the iterator itor, return tb_iterator_tail(iterator) if not found
  */
@@ -50,7 +50,7 @@ tb_size_t           tb_binary_find(tb_iterator_ref_t iterator, tb_size_t head, t
 /*!binary find item for all
  *
  * @param iterator  the iterator
- * @param item      the finded item
+ * @param item      the found item
  *
  * @return          the iterator itor, return tb_iterator_tail(iterator) if not found
  */

--- a/src/tbox/container/hash_map.c
+++ b/src/tbox/container/hash_map.c
@@ -201,7 +201,7 @@ static tb_bool_t tb_hash_map_item_find(tb_hash_map_t* hash_map, tb_cpointer_t na
 
     /* update item
      *
-     * @note: m is not the prev not same item if not finded and list has repeat items
+     * @note: m is not the prev not same item if not found and list has repeat items
      * but this hash_map not exists repeat
      *
      * @see tb_binary_pfind()

--- a/src/tbox/string/static_string.h
+++ b/src/tbox/string/static_string.h
@@ -123,7 +123,7 @@ tb_char_t               tb_static_string_charat(tb_static_string_ref_t string, t
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -133,7 +133,7 @@ tb_long_t               tb_static_string_strchr(tb_static_string_ref_t string, t
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -143,7 +143,7 @@ tb_long_t               tb_static_string_strichr(tb_static_string_ref_t string, 
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -153,7 +153,7 @@ tb_long_t               tb_static_string_strrchr(tb_static_string_ref_t string, 
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -163,7 +163,7 @@ tb_long_t               tb_static_string_strirchr(tb_static_string_ref_t string,
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -173,7 +173,7 @@ tb_long_t               tb_static_string_strstr(tb_static_string_ref_t string, t
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -183,7 +183,7 @@ tb_long_t               tb_static_string_stristr(tb_static_string_ref_t string, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -193,7 +193,7 @@ tb_long_t               tb_static_string_cstrstr(tb_static_string_ref_t string, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -203,7 +203,7 @@ tb_long_t               tb_static_string_cstristr(tb_static_string_ref_t string,
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -213,7 +213,7 @@ tb_long_t               tb_static_string_strrstr(tb_static_string_ref_t string, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -223,7 +223,7 @@ tb_long_t               tb_static_string_strirstr(tb_static_string_ref_t string,
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -233,7 +233,7 @@ tb_long_t               tb_static_string_cstrrstr(tb_static_string_ref_t string,
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */

--- a/src/tbox/string/string.h
+++ b/src/tbox/string/string.h
@@ -121,7 +121,7 @@ tb_char_t               tb_string_charat(tb_string_ref_t string, tb_size_t p);
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -131,7 +131,7 @@ tb_long_t               tb_string_strchr(tb_string_ref_t string, tb_size_t p, tb
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -141,7 +141,7 @@ tb_long_t               tb_string_strichr(tb_string_ref_t string, tb_size_t p, t
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -151,7 +151,7 @@ tb_long_t               tb_string_strrchr(tb_string_ref_t string, tb_size_t p, t
  *
  * @param string        the string
  * @param p             the start position
- * @param c             the finded charactor
+ * @param c             the found charactor
  *
  * @return              the real position, no find: -1
  */
@@ -161,7 +161,7 @@ tb_long_t               tb_string_strirchr(tb_string_ref_t string, tb_size_t p, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -171,7 +171,7 @@ tb_long_t               tb_string_strstr(tb_string_ref_t string, tb_size_t p, tb
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -181,7 +181,7 @@ tb_long_t               tb_string_stristr(tb_string_ref_t string, tb_size_t p, t
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -191,7 +191,7 @@ tb_long_t               tb_string_cstrstr(tb_string_ref_t string, tb_size_t p, t
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -201,7 +201,7 @@ tb_long_t               tb_string_cstristr(tb_string_ref_t string, tb_size_t p, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -211,7 +211,7 @@ tb_long_t               tb_string_strrstr(tb_string_ref_t string, tb_size_t p, t
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded string
+ * @param s             the found string
  *
  * @return              the real position, no find: -1
  */
@@ -221,7 +221,7 @@ tb_long_t               tb_string_strirstr(tb_string_ref_t string, tb_size_t p, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */
@@ -231,7 +231,7 @@ tb_long_t               tb_string_cstrrstr(tb_string_ref_t string, tb_size_t p, 
  *
  * @param string        the string
  * @param p             the start position
- * @param s             the finded c-string
+ * @param s             the found c-string
  *
  * @return              the real position, no find: -1
  */


### PR DESCRIPTION
This PR fixes the translation of the word `finded`, as it doesn't exist in English/American. It should be replaced with `found`, because `to find` is an irregular verb (`find/found/found`)