### PR TITLE
Unix domain socket: uninitialized value 'port' is used

### DIFF
--- a/src/tbox/network/ipaddr.c
+++ b/src/tbox/network/ipaddr.c
@@ -624,6 +624,9 @@ tb_bool_t tb_ipaddr_unix_set_cstr(tb_ipaddr_ref_t ipaddr, tb_char_t const* cstr,
     // have ip?
     temp.have_ip = 1;
 
+    // Set port to 0 = not used
+    temp.port = 0;
+
     // save ipaddr
     tb_ipaddr_copy(ipaddr, &temp);
     return tb_true;


### PR DESCRIPTION
The function `tb_socket_bind()` calls `tb_ipaddr_port()` which reads the value of  `ipaddr->port`

When using a unix domain socket, the value of `ipaddr->port` is never initialized before being read. The `ipaddr->port` value is then invalid/undefined.

Valgrind log:
```...
==54340== Thread 4:
==54340== Conditional jump or move depends on uninitialised value(s)
==54340==    at 0x48F7895: tb_socket_bind (socket.c:403)
```
-----
 This PR proposes to set  the `port` value to `0` inside the function `tb_ipaddr_unix_set_cstr()`

-----
This issue is reproducible using the `demo network_unix_echo_server` application.

