### PR TITLE
Add syslinks on linux for demo

### DIFF
--- a/src/demo/xmake.lua
+++ b/src/demo/xmake.lua
@@ -94,3 +94,6 @@ target("demo")
         add_syslinks("execinfo")
     end
 
+    if is_plat("linux") then
+        add_syslinks("pthread", "dl", "m", "c")
+    end


### PR DESCRIPTION
Fix #231 
Error message:
```
[2023-08-30 23:05:22] > /usr/bin/g++ -o /tmp/.xmake0/230830/_46243D59621B4F108FA2943ED05E8440.b /tmp/.xmake0/230830/_46243D59621B4F108FA2943ED05E8440.o -m64 -L/root/.xmake/packages/t/tbox/dev/7120a2256037488eba888d3e75fde43f/lib -ltbox -lpthread
[2023-08-30 23:05:22] /usr/bin/ld: /root/.xmake/packages/t/tbox/dev/7120a2256037488eba888d3e75fde43f/lib/libtbox.a(sqrtf.c.o): in function `tb_sqrtf':
[2023-08-30 23:05:22] sqrtf.c:(.text+0x5): undefined reference to `sqrtf'
[2023-08-30 23:05:22] collect2: error: ld returned 1 exit status
```