### PR TITLE
Option to spawn a process with CREATE_NO_WINDOW on windows

### DIFF
--- a/src/tbox/platform/process.h
+++ b/src/tbox/platform/process.h
@@ -43,7 +43,7 @@ typedef enum __tb_process_flag_e
     TB_PROCESS_FLAG_NONE    = 0
 ,   TB_PROCESS_FLAG_SUSPEND = 1     //!< suspend process
 ,   TB_PROCESS_FLAG_DETACH  = 2     //!< all subprocesses will be exited when the parent process is exited (ctrl+c or onexit) if this flag is not setted
-,   TB_PROCESS_FLAG_NO_WINDOW = 4   //!< avoid to launch the console
+,   TB_PROCESS_FLAG_NO_WINDOW = 4   //!< avoid to launch the console, currently only for windows when spawning command line in a GUI app
 
 }tb_process_flag_e;
 

--- a/src/tbox/platform/process.h
+++ b/src/tbox/platform/process.h
@@ -43,6 +43,7 @@ typedef enum __tb_process_flag_e
     TB_PROCESS_FLAG_NONE    = 0
 ,   TB_PROCESS_FLAG_SUSPEND = 1     //!< suspend process
 ,   TB_PROCESS_FLAG_DETACH  = 2     //!< all subprocesses will be exited when the parent process is exited (ctrl+c or onexit) if this flag is not setted
+,   TB_PROCESS_FLAG_NO_WINDOW = 4   //!< avoid to launch the console
 
 }tb_process_flag_e;
 

--- a/src/tbox/platform/windows/process.c
+++ b/src/tbox/platform/windows/process.c
@@ -261,8 +261,7 @@ tb_process_ref_t tb_process_init_cmd(tb_char_t const* cmd, tb_process_attr_ref_t
         // init flags
         // see: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
         DWORD flags = CREATE_UNICODE_ENVIRONMENT;
-        // the process is expected to be a console command line
-        flags |= CREATE_NO_WINDOW;
+        if (attr && attr->flags & TB_PROCESS_FLAG_NO_WINDOW) flags |= CREATE_NO_WINDOW;
         if (attr && attr->flags & TB_PROCESS_FLAG_SUSPEND) flags |= CREATE_SUSPENDED;
         if (!detach) flags |= CREATE_BREAKAWAY_FROM_JOB; // create process with parent process group by default, need set JOB_OBJECT_LIMIT_BREAKAWAY_OK limit for job
 

--- a/src/tbox/platform/windows/process.c
+++ b/src/tbox/platform/windows/process.c
@@ -259,7 +259,10 @@ tb_process_ref_t tb_process_init_cmd(tb_char_t const* cmd, tb_process_attr_ref_t
         tb_bool_t detach = attr && (attr->flags & TB_PROCESS_FLAG_DETACH);
 
         // init flags
+        // see: https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
         DWORD flags = CREATE_UNICODE_ENVIRONMENT;
+        // the process is expected to be a console command line
+        flags |= CREATE_NO_WINDOW;
         if (attr && attr->flags & TB_PROCESS_FLAG_SUSPEND) flags |= CREATE_SUSPENDED;
         if (!detach) flags |= CREATE_BREAKAWAY_FROM_JOB; // create process with parent process group by default, need set JOB_OBJECT_LIMIT_BREAKAWAY_OK limit for job
 


### PR DESCRIPTION
close #244 

In most cases, the spawned process is console app without UI. That's why I set the CREATE_NO_WINDOW flag directly.