### PR TITLE
fix error: unknown type name 'wchar_t'

### DIFF
--- a/src/xmake.sh
+++ b/src/xmake.sh
@@ -57,6 +57,7 @@ option "deprecated" "Enable or disable the deprecated interfaces." false
 option "force_utf8" "Forcely regard all tb_char* as utf-8." false
 
 option "wchar"
+    add_cincludes "stddef.h"
     add_ctypes "wchar_t"
 option_end
 


### PR DESCRIPTION
```

typedef wchar_t __type_wchar_t;\n\nint main(int argc, char** argv) {

    return 0;
}
> x86_64-w64-mingw32-gcc -c  -o /tmp/tmp.9lz8KrU05i.o /tmp/tmp.9lz8KrU05i.c
C:/Windows/TEMP/tmp.9lz8KrU05i.c:2:9: error: unknown type name 'wchar_t'
    2 | typedef wchar_t __type_wchar_t;
      |         ^~~~~~~
C:/Windows/TEMP/tmp.9lz8KrU05i.c:1:1: note: 'wchar_t' is defined in header '<stddef.h>'; this is probably fixable by adding '#include <stddef.h>'
  +++ |+#include <stddef.h>
    1 |
> checking for c types(wchar_t)
checking for wchar .. no
```
