### PR TITLE
fix(tb_putchar): stdin => stdout

### DIFF
--- a/src/tbox/libc/stdio/putchar.c
+++ b/src/tbox/libc/stdio/putchar.c
@@ -34,5 +34,5 @@
 
 tb_int_t tb_putchar(tb_int_t ch)
 {
-    return tb_stdfile_putc(tb_stdfile_input(), (tb_char_t)ch)? ch : TB_EOF;
+    return tb_stdfile_putc(tb_stdfile_output(), (tb_char_t)ch)? ch : TB_EOF;
 }


### PR DESCRIPTION
### tbox trace:
```
[tbox]: [platform_stdfile]: [assert]: expr[stdfile->type != TB_STDFILE_TYPE_STDIN] at tb_stdfile_putc(): 189, src/tbox/platform/libc/stdfile.c at tb_assert_impl(): 300, src/tbox/platform/../prefix/assert.h
[tbox]: [backtrace]:     [0x007ffff7ee4569]: /usr/local/lib/libtbox.so.1(+0x91569) [0x7ffff7ee4569]
[tbox]: [backtrace]:     [0x007ffff7ee4d2d]: /usr/local/lib/libtbox.so.1(tb_stdfile_putc+0x93) [0x7ffff7ee4d2d]
[tbox]: [backtrace]:     [0x007ffff7e81473]: /usr/local/lib/libtbox.so.1(tb_putchar+0x21) [0x7ffff7e81473]
```
### problem:
tb_stdfile_intput instead of tb_stdfile_output

### solution:
replace tb_stdfile_intput => tb_stdfile_output