### PR TITLE
add condition for wasm toolchain selection

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -30,7 +30,7 @@ if has_config("coroutine") then
 end
 
 -- set wasm toolchain
-if is_plat("wasm") then
+if is_plat("wasm") and not has_config("toolchain") then
     add_requires("emscripten")
     set_toolchains("emcc@emscripten")
 end


### PR DESCRIPTION
What?

Add a `not has_config("toolchain")` guard to the `set_toolchain()` calls for the wasm platform.

Why?

The current build script still switches the toolchain even when lolly is built as a dependency. However, dependencies should inherit the toolchain from their parent project to ensure a consistent build environment across the entire dependency graph.

This change prevents the existing toolchain configuration from being overridden when one has already been specified by the parent project, while preserving the default behavior when no toolchain is explicitly configured.