### PR TITLE
Fix memcpy size calculation in native_large_allocator

### DIFF
--- a/src/demo/container/heap.c
+++ b/src/demo/container/heap.c
@@ -95,7 +95,7 @@ static tb_void_t tb_test_heap_min_perf()
     // profile
     __tb_volatile__ tb_size_t i = 0;
     __tb_volatile__ tb_size_t n = 100000;
-    __tb_volatile__ tb_size_t p; tb_used(&p);
+    __tb_volatile__ tb_size_t p = 0; tb_used(&p);
     for (i = 0; i < n; i++) tb_heap_put(heap, (tb_pointer_t)(tb_size_t)tb_random_range(0, 50));
     for (i = 0; tb_heap_size(heap); i++)
     {
@@ -205,7 +205,7 @@ static tb_void_t tb_test_heap_max_perf()
     // profile
     __tb_volatile__ tb_size_t i = 0;
     __tb_volatile__ tb_size_t n = 100000;
-    __tb_volatile__ tb_size_t p; tb_used(&p);
+    __tb_volatile__ tb_size_t p = 0; tb_used(&p);
     for (i = 0; i < n; i++) tb_heap_put(heap, (tb_pointer_t)(tb_size_t)tb_random_range(0, 50));
     for (i = 0; tb_heap_size(heap); i++)
     {

--- a/src/tbox/memory/impl/native_large_allocator.c
+++ b/src/tbox/memory/impl/native_large_allocator.c
@@ -359,7 +359,7 @@ static tb_pointer_t tb_native_large_allocator_ralloc(tb_allocator_ref_t self, tb
                 data = (tb_byte_t*)tb_virtual_memory_malloc(need);
                 if (data)
                 {
-                    tb_memcpy_(data, data_head, base_head->size);
+                    tb_memcpy_(data, data_head, sizeof(tb_native_large_data_head_t) + tb_min(base_head->size, size));
                     tb_native_memory_free(data_head);
                 }
             }
@@ -373,7 +373,7 @@ static tb_pointer_t tb_native_large_allocator_ralloc(tb_allocator_ref_t self, tb
                 data = (tb_byte_t*)tb_native_memory_malloc(need);
                 if (data)
                 {
-                    tb_memcpy_(data, data_head, base_head->size);
+                    tb_memcpy_(data, data_head, sizeof(tb_native_large_data_head_t) + tb_min(base_head->size, size));
                     tb_virtual_memory_free(data_head);
                 }
             }


### PR DESCRIPTION
```xmake bundles tbox in small mode, where the virtual-memory path is compiled out — on every OS. Any full tbox build (like FreeBSD's --small=no package) has the bug everywhere. ```

This fixes a data corruption bug in tb_native_large_allocator_ralloc() when a reallocation crosses TB_VIRTUAL_MEMORY_DATA_MINN and the allocation moves between the native allocator and the virtual-memory allocator.

There are two crossover paths:

native memory block => virtual-memory block
virtual-memory block => native memory block

Both currently copy the old block with:

```c
tb_memcpy_(data, data_head, base_head->size);
```

However, data_head points to the beginning of the internal allocation block, including tb_native_large_data_head_t, while base_head->size is only the old user payload size.

That means the copy starts from the header but copies only the payload length. As a result, the last sizeof(tb_native_large_data_head_t) bytes of the old user data are not copied correctly when growing across the threshold.

In the opposite direction, when shrinking from virtual memory back to native memory, the old payload size can be larger than the new requested size. Because the copy starts at the header and uses the old payload size, this can also write past the new allocation size.

The fix is to copy the internal header plus the smaller of the old and new payload sizes:

```c
tb_memcpy_(data, data_head,
    sizeof(tb_native_large_data_head_t) + tb_min(base_head->size, size));
```

This preserves the allocator header and copies only the valid overlapping user data.

Reproduce:
1. Install freebsd on qemu
2. Install xmake-io package `pkg install xmake-io`
3. Execute `xmake` in console

<img width="1507" height="333" alt="image" src="https://github.com/user-attachments/assets/ad94fcfc-a2f2-4128-84c2-669b19dd27b4" />

After supplying patch:

<img width="766" height="634" alt="image" src="https://github.com/user-attachments/assets/d0a1b7f8-707c-4e1a-b06a-b76af9e25d50" />
