### PR TITLE
Add ANSI passthrough for file output encoding

### DIFF
--- a/src/tbox/platform/windows/stdfile.c
+++ b/src/tbox/platform/windows/stdfile.c
@@ -276,11 +276,16 @@ tb_stdfile_ref_t tb_stdfile_init(tb_size_t type)
                 file->ofstream = tb_stream_init_filter_from_charset(file->ostream, encoding, TB_CHARSET_TYPE_UTF16 | TB_CHARSET_TYPE_LE);
                 tb_assert_and_check_break(file->ofstream);
             }
-            else
+            else if (encoding == TB_CHARSET_TYPE_UTF8)
             {
                 // redirect (console output cp)
                 file->ofstream = tb_stream_init_filter_from_charset(file->ostream, encoding, TB_CHARSET_TYPE_COCP);
                 tb_assert_and_check_break(file->ofstream);
+            }
+            else
+            {
+                // no charset filter needed for ANSI passthrough
+                file->ofstream = file->ostream;
             }
 
             // open stream


### PR DESCRIPTION
So workaround for ```TB_CONFIG_FORCE_UTF8=0``` output

1. In [src/tbox/platform/windows/stdfile.c](https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/stdfile.c#L279-L288) [(https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/stdfile.c#L279-L288)](https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/stdfile.c#L279-L288):
When stdout is redirected (is_console == false), tb_stdfile_init initializes a charset filter:
```c
file->ofstream = tb_stream_init_filter_from_charset(file->ostream, encoding, TB_CHARSET_TYPE_COCP);
if (!tb_stream_open(file->ofstream)) break;
```
2. When tbox is built without TB_CONFIG_FORCE_UTF8, encoding is TB_CHARSET_TYPE_ANSI (0x01).
3. tb_stream_open requests a charset conversion from TB_CHARSET_TYPE_ANSI (0x01) to TB_CHARSET_TYPE_COCP (0x11).
4. In [src/tbox/platform/windows/charset.c](https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/charset.c#L311-L348) [(https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/charset.c#L311-L348)](https://github.com/tboox/tbox/blob/b3af9a9e3a714eae58e8aea82f1479592c567c74/src/tbox/platform/windows/charset.c#L311-L348)
(tb_charset_conv_impl), there is no case for ANSI -> COCP, so it returns -1 (failure).
5. tb_stream_open fails => tb_stdfile_init aborts and returns NULL => tb_stdfile_output() is NULL => all output is dropped.

